### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ services:
       - store:/store
     restart: unless-stopped
     environment:
-      - OTR_HOST: "mqtt_broker"
-      - OTR_USER: "user"
-      - OTR_PASS: "pass"
+      - OTR_HOST = "mqtt_broker"
+      - OTR_USER = "user"
+      - OTR_PASS = "pass"
 
 volumes:
   store:


### PR DESCRIPTION
docker-compose config
   ERROR: The Compose file './docker-compose.yml' is invalid because:
   services.otrecorder.environment contains {"OTR_HOST": "mosquitto"}, which is an invalid type, it should be a string
grep OTR docker-compose.yml
      - OTR_HOST: mosquitto
      - OTR_USER: "user"
      - OTR_PASS: "paass"