### PR TITLE
Update entrypoint to allow passing arguments to ot-recorder

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ if [ ! -f /config/recorder.conf ]; then
 fi
 
 ot-recorder --initialize
-ot-recorder
+ot-recorder "$@"


### PR DESCRIPTION
This will allow for passing custom arguments to ot-recorder without having to roll your own image. For example you could suddenly run `docker run owntracks/recorder --lua-script /usr/bin/example.lua`.