### PR TITLE
Updated entrypoint.sh to not forget arguments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@
 # and re-run this script as appuser.
 if [[ $(id -u) -eq 0 ]]; then
   chown -R appuser:appuser /store /config
-  exec su -c "$0" appuser
+  exec su appuser -- "$0" "$@"
 fi
 
 # Load Default recorder.conf if not available


### PR DESCRIPTION
When running as root this script would get executed as the appuser, but the possible arguments would be forgotten.