### PR TITLE
Allows all users to read /config/recorder.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY recorder-health.sh /usr/sbin/recorder-health.sh
 COPY entrypoint.sh /usr/sbin/entrypoint.sh
 
 RUN chmod +x /usr/sbin/*.sh
+RUN chmod +r /config/recorder.conf
 
 # If you absolutely need health-checking, enable the option below.  Keep in
 # mind that until https://github.com/systemd/systemd/issues/6432 is resolved,


### PR DESCRIPTION
The Docker image adds /config/recorder.conf with mode 0640. When running the container using a non-root user this results in an error - "Cannot read defaults from /config/recorder.conf: Permission denied" This change will make the file readable by everyone and remove the error from the log