### PR TITLE
Allow passing CLI args to recorder

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ if ! [ -f ${OTR_STORAGEDIR}/ghash/data.mdb ]; then
     ot-recorder --initialize
 fi
 
-ot-recorder ${OTR_TOPIC}
+ot-recorder ${OTR_TOPIC} "$@"


### PR DESCRIPTION
This lets e.g. pass `--norevgeo` using nicer docker compose syntax:

```yaml
recorder:
    image: owntracks/recorder
    command:
        - --norevgeo
```

as opposed to the very hacky alternative which works with the current image:

```yaml
recorder:
    image: owntracks/recorder
    environment:
        - OTR_TOPIC = owntracks/# --norevgeo
```