### PR TITLE
Bump alpine version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS builder
+FROM alpine:3.21.0 AS builder
 
 ARG RECORDER_VERSION=0.9.9
 # ARG RECORDER_VERSION=master
@@ -26,7 +26,7 @@ COPY config.mk .
 RUN make -j $(nprocs)
 RUN make install DESTDIR=/app
 
-FROM alpine:3.16
+FROM alpine:3.21.0
 
 ENV DOCKER_RUNNING=1
 


### PR DESCRIPTION
- Alpine 3.16 has reached it's EOL 6 months ago, bump it to 3.21.0
- Enable dependabot to automatically create PRs for Dockerfile