### PR TITLE
Make Default MQTT Docker Compose YAML Runnable

### DIFF
--- a/docker-compose-mqtt.yml
+++ b/docker-compose-mqtt.yml
@@ -10,6 +10,8 @@ services:
     restart: unless-stopped
     environment:
       OTR_HOST: mosquitto
+    depends_on:
+      - mosquitto
 
   mosquitto:
     image: eclipse-mosquitto
@@ -20,6 +22,9 @@ services:
       - mosquitto-data:/mosquitto/data
       - mosquitto-logs:/mosquitto/logs
       - mosquitto-conf:/mosquitto/config
+    # Use the built-in example config to accept connections from otrecorder.
+    # Replace this config with your own to accept connections from mobile clients.
+    command: mosquitto -c /mosquitto-no-auth.conf
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
# Summary
This PR reduces the initial troubleshooting needed when attempting to run `docker compose up` using [docker-compose-mqtt.yml](https://github.com/owntracks/docker-recorder/blob/master/docker-compose-mqtt.yml).

# Rationale
Currently, this docker compose file does not run without some configuration. Because this docker compose file may be the first file a user attempts to run in this project, this initial roadblock could cause a portion of the prospective user base to bounce off the project when this docker compose file fails.

# The Issue
The default config only allows connections from localhost, but otrecorder is attempting to connect over the docker network. 

## Changes
A additional `command:` option was added to the mosquitto service so that it uses the built-in no-auth config that allows the otrecorder service to connect to the mosquitto service.

### Security Implications
Since the default docker network is restricted to these two services, there is no risk of unauthenticated messages being published to the broker with this config. In order to connect a mobile app to the MQTT server, a user will still have to learn how to update the config file themself to enable additional ports and define an authentication scheme.

### Bonus
This PR also adds a `depends_on` option to the otrecorder service to reduce error messages due to it starting before the mosquitto service.